### PR TITLE
Move the Tax Report Menu to bottom

### DIFF
--- a/class-taxreport.php
+++ b/class-taxreport.php
@@ -33,9 +33,9 @@ class TaxReport {
   public function customer_menu_item($items) {
     return
     array_merge(
-      array_slice( $items, 0, count( $items ) - 4 ),
+      array_slice( $items, 0, count( $items ) ),
       array( 'taxreport' => 'Tax Report' ),
-      array_slice( $items, count( $items ) - 4 )
+      array_slice( $items, count( $items ) )
     );
   }
 


### PR DESCRIPTION
The -4 flag moves the menu item to the top of the list, probably best to remove this and let it live near the bottom.